### PR TITLE
BotMark improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ simple_logger = "5.0.0"
 clap = { version = "4.5.30", features = ["derive"] }
 # Networking
 tokio = { version = "1.43.0", features = ["net", "io-util"] }
-pumpkin-protocol = { git = "https://github.com/Pumpkin-MC/Pumpkin", package = "pumpkin-protocol", default-features = false, features = ["packets"]}
+pumpkin-protocol = { git = "https://github.com/Pumpkin-MC/Pumpkin", package = "pumpkin-protocol", default-features = false, features = ["packets"] }
 
 crossbeam = "0.8.4"
 uuid = "1.14.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,10 +41,12 @@ pub struct Client {
     pub connection_reader: Mutex<OwnedReadHalf>,
     pub connection_writer: Mutex<OwnedWriteHalf>,
     pub client_packets_queue: Arc<Mutex<VecDeque<RawPacket>>>,
+    // Its read-only and not needs AtomicBool
+    realistic: bool
 }
 
 impl Client {
-    pub fn new(stream: TcpStream) -> Self {
+    pub fn new(stream: TcpStream, realistic: bool) -> Self {
         let (connection_reader, connection_writer) = stream.into_split();
         Self {
             connection_state: AtomicCell::new(ConnectionState::HandShake),
@@ -54,6 +56,7 @@ impl Client {
             connection_reader: Mutex::new(connection_reader),
             connection_writer: Mutex::new(connection_writer),
             client_packets_queue: Arc::new(Mutex::new(VecDeque::new())),
+            realistic,
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,6 @@ use pumpkin_protocol::{
     packet_decoder::PacketDecoder, packet_encoder::PacketEncoder,
 };
 use std::collections::VecDeque;
-use std::net::SocketAddr;
 use std::sync::{Arc, atomic::AtomicBool};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::{
@@ -170,11 +169,11 @@ impl Client {
         }
     }
 
-    pub async fn join_server(&self, address: SocketAddr, name: String) {
+    pub async fn join_server(&self, ip: String, port: u16, name: String) {
         self.send_packet(&SHandShake {
             protocol_version: VarInt(CURRENT_MC_PROTOCOL.get() as i32),
-            server_address: address.ip().to_string(),
-            server_port: address.port(),
+            server_address: ip,
+            server_port: port,
             next_state: pumpkin_protocol::ConnectionState::Login,
         })
         .await;
@@ -214,7 +213,7 @@ impl Client {
                 .await
             }
             CLoginDisconnect::PACKET_ID => {
-                log::error!("Kicking in Login State");
+                log::error!("Kicking in Login State with reason:\n{}", String::from_utf8_lossy(packet.bytebuf.iter().as_slice()));
                 self.close().await;
             }
             CLoginSuccess::PACKET_ID => {


### PR DESCRIPTION
Improved speed of connections, now connections in new thread instead of running in loop. Removed tasks, because its non beeded and just wastes memory. Client can disconnect not normal and server need to handle it, its like you close minecraft window and not press disconnect.
Changed socketaddr to text. Now its sends address normally in handshake. Port now spearated too for not always add :25565.
Added --realistic. Its for future improvements. Realistic can handle gravity, pushes, damage and etc, but not now.